### PR TITLE
Enable Gedmo soft-deleteable extension

### DIFF
--- a/classes/CMF/Doctrine/Extensions/SoftDeletable.php
+++ b/classes/CMF/Doctrine/Extensions/SoftDeletable.php
@@ -13,8 +13,10 @@ class SoftDeletable extends Extension
 	{
 		$listener = new \Gedmo\SoftDeleteable\SoftDeleteableListener();
 		$listener->setAnnotationReader($reader);
-		$em->getEventManager()->addEventSubscriber($listener);
+        //$em->addEventListener('onFlush', $listener);
+        $em->getEventManager()->addEventSubscriber($listener);
 		$em->getConfiguration()->addFilter('soft-deleteable', 'Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter');
+		$em->getFilters()->enable('soft-deleteable'); // Filters queries, soft-deleted items will not be retrieved.
 	}
 	
 }

--- a/classes/CMF/Model/Base.php
+++ b/classes/CMF/Model/Base.php
@@ -2,6 +2,7 @@
 
 namespace CMF\Model;
 
+use CMF\Field\DateTime;
 use Doctrine\ORM\Mapping as ORM,
     Doctrine\ORM\Mapping\ClassMetadataInfo,
     Doctrine\DBAL\LockMode,
@@ -11,6 +12,7 @@ use Doctrine\ORM\Mapping as ORM,
 /**
  * @ORM\MappedSuperclass
  * @ORM\HasLifecycleCallbacks
+ * @Gedmo\SoftDeleteable(fieldName="deleted_at", timeAware=false)
  **/
 class Base extends \CMF\Doctrine\Model implements \JsonSerializable
 {
@@ -30,9 +32,14 @@ class Base extends \CMF\Doctrine\Model implements \JsonSerializable
     /**
      * @Gedmo\Timestampable(on="update")
      * @ORM\Column(type="datetime")
-     * @var datetime
+     * @var Datetime
      **/
     protected $updated_at;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    protected $deleted_at = null;
     
     /**
      * @ORM\Column(type="object", nullable=true)
@@ -74,6 +81,7 @@ class Base extends \CMF\Doctrine\Model implements \JsonSerializable
     	'id' => array( 'visible' => false ),
     	'created_at' => array( 'readonly' => true, 'visible' => false, 'format' => 'Y-m-d H:i:s' ),
     	'updated_at' => array( 'readonly' => true, 'visible' => false, 'format' => 'Y-m-d H:i:s' ),
+        'deleted_at' => array( 'readonly' => true, 'visible' => false, 'format' => 'Y-m-d H:i:s' ),
         'visible' => array( 'visible' => false ),
         'settings' => array( 'visible' => false, 'fields' => array(
             'original_id' => array( 'type' => 'integer' )

--- a/config/db.php
+++ b/config/db.php
@@ -29,9 +29,9 @@ return array(
 			'CMF\\Doctrine\\Extensions\\Spatial',
 			'CMF\\Doctrine\\Extensions\\URL',
 			'CMF\\Doctrine\\Extensions\\Sortable',
-			//'CMF\\Doctrine\\Extensions\\Translatable',
+            'CMF\\Doctrine\\Extensions\\SoftDeletable'
+            //'CMF\\Doctrine\\Extensions\\Translatable',
 			//'CMF\\Doctrine\\Extensions\\Loggable',
-			//'CMF\\Doctrine\\Extensions\\SoftDeletable'
 		),
 		
 		/**


### PR DESCRIPTION
Gedmo soft-deletable extension enabled in the config and filter enabled to exclude soft-deleted items from query.

deleted_at field added to CMF\Model\Base, nullable field with default as null. Hidden from UI with visible -> false.